### PR TITLE
Refactors attributedStringForIndex so it only applies margins when needed

### DIFF
--- a/Samples/Podfile.lock
+++ b/Samples/Podfile.lock
@@ -11,12 +11,12 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Iconic:
-    :commit: 5d56b49810ba9b3c4bd0870aa0ef3430845b3eca
+    :commit: 6c88e9346dd57b0a48504b0afbae401d39529c5b
     :git: https://github.com/dzenbot/Iconic.git
     :submodules: true
 
 SPEC CHECKSUMS:
-  Iconic: 0633e637143e9528e78ab3051e8220dd1cad16d4
+  Iconic: 9f0b62ebb6f77d320aff81f66f9dfc11a34f85d6
 
 PODFILE CHECKSUM: 76c8b6f4ca4f3f5b6dc05290c88c84144de3155b
 

--- a/Samples/Pods/Iconic/README.md
+++ b/Samples/Pods/Iconic/README.md
@@ -35,7 +35,7 @@ _Great. Now, how do I create an icon font,_ you say?
 - You can ask your nearest friendly designer! Making an icon font isn't that hard, specially if you already have the assets.
 - There are many [open sourced icon fonts](http://fontello.com/) out there (most are available under the [SIL Open Font License](http://scripts.sil.org/OFL)). They are designed for the web but they are still very useful for iOS.
 - You can [read this article](http://rafaltomal.com/how-to-create-and-use-your-own-icon-fonts/) and give [fontastic.me](http://fontastic.me/) a shot.
-- Check out the [icon fonts available in this repo](./Playground/Fonts).
+- Check out the [icon fonts available in this repo](./Samples/Fonts).
 
 
 ## Key Features
@@ -116,22 +116,23 @@ Iconic.registerFont("FontAwesome", map: FontAwesomeIconMap)
 ### Use as images
 You can construct an `UIImage` instance out of a font's icon and tint it. This may be very convenient for integrating with existing UIKit controls which expect `UIImage` objects already.
 ```swift
-let image = Iconic.imageForFontAwesomeIcon(.CaretRight, size: 16, color: self.view.tintColor)
+let image = Iconic.imageForFontAwesomeIcon(.Home, size: 20, color: .blueColor())
 let imageView = UIImageView(image: image)
 ```
 
 Images are created using NSStringDraw APIs to render a `UIImage` out of an `NSAttributedString`.
 
 ### Use as attributed strings
-You may need to icons as text too, to simplify your layout work.
+You may need to icons as text too, and simplify your layout work.
 For example, instead of having an image and a label, you can combined it all in one single label:
 ```swift
-let iconString = Iconic.attributedStringForFontAwesomeIcon(.Home, size: 20, color: .orangeColor())
+let edgeInsets = UIEdgeInsetsMake(0, 0, 0, 10)
+let iconString = Iconic.attributedStringForFontAwesomeIcon(.Home, size: 20, color: .blueColor(), edgeInsets: edgeInsets)
 
-let attributes = [NSForegroundColorAttributeName: UIColor.orangeColor(),
-                  NSFontAttributeName: UIFont.boldSystemFontOfSize(20)]
+let attributes = [NSForegroundColorAttributeName: UIColor.blueColor(),
+                  NSFontAttributeName: UIFont.systemFontOfSize(20)]
 
-let labelString = NSMutableAttributedString(string: "  Home", attributes: attributes)
+let labelString = NSMutableAttributedString(string: "Home", attributes: attributes)
 labelString.insertAttributedString(iconString!, atIndex: 0)
 
 let label = UILabel()

--- a/Samples/Pods/Iconic/Source/Iconizer/catalog/catalog.html
+++ b/Samples/Pods/Iconic/Source/Iconizer/catalog/catalog.html
@@ -1,16 +1,18 @@
-<!DOCTYPE html><html lang="en-US"><head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<!DOCTYPE html>
+<html lang="en-US">
 
-<script type="text/javascript" src="html/data.json"></script>
-<script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
-<script type="text/javascript" src="html/script.js"></script>
-
-<link type="text/css" rel="stylesheet" href="html/style.css">
-
-<title>Icon Font Reference</title>
-<html>
 <head>
-	<header name = "Access-Control-Allow-Origin" value = "*" />
+  <header name="Access-Control-Allow-Origin" value="*" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <script type="text/javascript" src="html/data.json"></script>
+  <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
+  <script type="text/javascript" src="html/script.js"></script>
+  <link type="text/css" rel="stylesheet" href="html/style.css">
+  <title>Icon Font Reference</title>
 </head>
-<body></body>
+
+<body>
+
+</body>
+
 </html>

--- a/Samples/Pods/Iconic/Source/Iconizer/catalog/html/style.css
+++ b/Samples/Pods/Iconic/Source/Iconizer/catalog/html/style.css
@@ -1,26 +1,95 @@
-<style type="text/css">
+@font-face {
+  font-style: normal;
+  font-weight: 100;
+}
 
-	@font-face {
-	  font-style:   normal;
-	  font-weight:  100;
-	}
+/* General layout */
+body {
+  margin: 40px;
+  font-size: 22px;
+  font-family: Helvetica, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
 
-	/* General layout */
-	body { margin:40px; font-size: 22px; font-family: Helvetica, sans-serif; -webkit-font-smoothing:antialiased;}
-	div { padding: 0 0 15px; }
-	ul {clear:both; overflow: hidden; padding: 0 0 5px; margin: 30px 0 50px; list-style-type: none;}
+div {
+  padding: 0 0 15px;
+}
 
-	li {float:left; width:150px; height:130px; border:1px solid #DDD; border-radius: 2px; margin:0 10px 10px 0; text-align: center; position: relative;}
-	li i {position: absolute; bottom:4px; left:4px; right:4px; background: #AAA; min-height:14px; padding: 4px 0; font-style:normal; font-weight:400; font-size:16px; color: #fff; border-radius: 2px;}
-	li:hover { background-color: #f2f2f2;}
+ul {
+  clear: both;
+  overflow: hidden;
+  padding: 0 0 5px;
+  margin: 30px 0 50px;
+  list-style-type: none;
+}
 
-	code {display: block; font-size: 14px; margin:10px; color: #888; }
+li {
+  float: left;
+  width: 150px;
+  height: 130px;
+  border: 1px solid #DDD;
+  border-radius: 2px;
+  margin: 0 10px 10px 0;
+  text-align: center;
+  position: relative;
+}
 
-	.title {font-size: 30px; font-weight:500;}
-	.subtitle {font-size: 18px; font-weight:200; color: #888;}
-	.icon {font-size: 50px; padding: 4px 0; color: #000;}
-	.footer {font-size: 15px; text-align: center; font-weight:200; color: #888;}
+li i {
+  position: absolute;
+  bottom: 4px;
+  left: 4px;
+  right: 4px;
+  background: #AAA;
+  min-height: 14px;
+  padding: 4px 0;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 16px;
+  color: #fff;
+  border-radius: 2px;
+}
 
-	a { color: #0e9df2; text-decoration: none;}
-	a:hover { color: #86cef8; text-decoration: none;}
-</style>
+li:hover {
+  background-color: #f2f2f2;
+}
+
+code {
+  display: block;
+  font-size: 14px;
+  margin: 10px;
+  color: #888;
+}
+
+.title {
+  font-size: 30px;
+  font-weight: 500;
+}
+
+.subtitle {
+  font-size: 18px;
+  font-weight: 200;
+  color: #888;
+}
+
+.icon {
+  font-size: 50px;
+  padding: 4px 0;
+  color: #000;
+}
+
+.footer {
+  font-size: 15px;
+  text-align: center;
+  font-weight: 200;
+  color: #888;
+}
+
+a {
+  color: #0e9df2;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #86cef8;
+  text-decoration: none;
+}

--- a/Samples/Pods/Local Podspecs/Iconic.podspec.json
+++ b/Samples/Pods/Local Podspecs/Iconic.podspec.json
@@ -28,5 +28,5 @@
     "ios": "8.0",
     "tvos": "9.0"
   },
-  "prepare_command": "cd Vendor/SwiftGen/ && rake install\ncd ../..\nsh Source/Iconizer/Iconizer.sh Playground/Fonts/FontAwesome.ttf Source/ --verbose"
+  "prepare_command": "cd Vendor/SwiftGen/ && rake install\ncd ../..\nsh Source/Iconizer/Iconizer.sh Samples/Fonts/FontAwesome.ttf Source/ --verbose"
 }

--- a/Samples/Pods/Manifest.lock
+++ b/Samples/Pods/Manifest.lock
@@ -11,12 +11,12 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   Iconic:
-    :commit: 5d56b49810ba9b3c4bd0870aa0ef3430845b3eca
+    :commit: 6c88e9346dd57b0a48504b0afbae401d39529c5b
     :git: https://github.com/dzenbot/Iconic.git
     :submodules: true
 
 SPEC CHECKSUMS:
-  Iconic: 0633e637143e9528e78ab3051e8220dd1cad16d4
+  Iconic: 9f0b62ebb6f77d320aff81f66f9dfc11a34f85d6
 
 PODFILE CHECKSUM: 76c8b6f4ca4f3f5b6dc05290c88c84144de3155b
 

--- a/Source/Iconic.swift
+++ b/Source/Iconic.swift
@@ -60,35 +60,36 @@ public class Iconic: NSObject {
     
     class func attributedStringForIndex(idx: Int, size: CGFloat, color: UIColor?) -> NSAttributedString? {
 
-        return attributedStringForIndex(idx, size: size, color: color, edgeInsets: UIEdgeInsetsZero)
-    }
-    
-    class func attributedStringForIndex(idx: Int, size: CGFloat, color: UIColor?, edgeInsets: UIEdgeInsets) -> NSAttributedString? {
-        
         guard let font = iconFontOfSize(size), let unicode = unicodeStringForIndex(idx) else {
             return nil
         }
         
-        let string = " " + unicode + " "
-        
-        var attributes = [NSFontAttributeName: font,
-                          NSBaselineOffsetAttributeName: edgeInsets.bottom-edgeInsets.top]
+        var attributes = [String : AnyObject]()
+        attributes[NSFontAttributeName] = font
         
         if let color = color {
             attributes[NSForegroundColorAttributeName] = color
         }
         
-        let attrString = NSAttributedString(string: string, attributes: attributes).mutableCopy()
+        return NSAttributedString(string: unicode, attributes: attributes)
+    }
+    
+    class func attributedStringForIndex(idx: Int, size: CGFloat, color: UIColor?, edgeInsets: UIEdgeInsets) -> NSAttributedString? {
         
-        if edgeInsets.left > 0 {
-            attrString.setAttributes([NSKernAttributeName: edgeInsets.left], range: NSMakeRange(0, 1))
+        guard let string = attributedStringForIndex(idx, size: size, color: color) else {
+            return nil
         }
         
-        if edgeInsets.right > 0 {
-            attrString.setAttributes([NSKernAttributeName: edgeInsets.right], range: NSMakeRange(2, 1))
-        }
+        let mutableString = string.mutableCopy()
+        mutableString.addAttributes([NSBaselineOffsetAttributeName: edgeInsets.bottom-edgeInsets.top], range: NSMakeRange(0, string.length))
         
-        return attrString as? NSAttributedString
+        let leftSpace = NSAttributedString(string: " ", attributes: [NSKernAttributeName: edgeInsets.left])
+        let rightSpace = NSAttributedString(string: " ", attributes: [NSKernAttributeName: edgeInsets.right])
+
+        mutableString.insertAttributedString(rightSpace, atIndex: string.length)
+        mutableString.insertAttributedString(leftSpace, atIndex: 0)
+        
+        return mutableString as? NSAttributedString
     }
     
     class func imageForIndex(idx: Int, size: CGFloat, color: UIColor?) -> UIImage? {


### PR DESCRIPTION
Using 0 margins by default was causing bad image rendering.
Works as expected now, for vertical and horizontal alignments.