### PR TITLE
Revert "Uses the versioned SwiftGen build, instead of building everytime. This should speed up installation."

### DIFF
--- a/Iconic.podspec
+++ b/Iconic.podspec
@@ -34,6 +34,8 @@ Pod::Spec.new do |s|
   font_path = ENV['FONT_PATH'] ? ENV['FONT_PATH'] : 'Samples/Fonts/FontAwesome.ttf'
 
   s.prepare_command = <<-CMD
+                      cd Vendor/SwiftGen/ && rake install
+                      cd ../..
                       sh Source/Iconizer/Iconizer.sh #{font_path} Source/ --verbose
                       CMD
 


### PR DESCRIPTION
This reverts commit 3be5fbf7d8ba92a70f7e8782a12f85f36a6e7a16.

I need to test this more throughout the day. Although it speeded up the installation process, while performing a remote `pod install`, Swiftgen would be not be executed and no output would be created. It works just fine with a local `pod install`.