### PR TITLE
More code cleanup

### DIFF
--- a/Samples/UnitTests/FontRegistrationTests.swift
+++ b/Samples/UnitTests/FontRegistrationTests.swift
@@ -14,22 +14,21 @@ class FontRegistrationTests: XCTestCase {
     let kFakeMap = ["",""]
     
     override func setUp() {
-        
         super.setUp()
     }
     
     override func tearDown() {
         
-        Iconic.unregisterAllFonts()
+        Iconic.unregisterFont()
         
         super.tearDown()
     }
     
     func testRegisteringFontInBundle() {
         
-        Iconic.registerFont(kFontName, map: kFakeMap)
+        Iconic.registerFont(withName: kFontName, map: kFakeMap)
         
-        let font = Iconic.iconFontOfSize(10)
+        let font = Iconic.iconFont(ofSize: 10)
         
         XCTAssertNotNil(font)
         XCTAssertEqual(font?.familyName, kFontName)
@@ -40,35 +39,32 @@ class FontRegistrationTests: XCTestCase {
         let bundle = NSBundle(forClass: self.dynamicType)
         let path = bundle.pathForResource(kFontName, ofType: "otf")
         
-        Iconic.registerFontWithPath(path!, map: kFakeMap)
+        Iconic.registerFont(withPath: path!, map: kFakeMap)
         
-        let font = Iconic.iconFontOfSize(10)
+        let font = Iconic.iconFont(ofSize: 10)
         
         XCTAssertNotNil(font)
         XCTAssertEqual(font?.familyName, kFontName)
-        
-        let zeroFont = Iconic.iconFontOfSize(0)
-        
-        XCTAssertNil(zeroFont)
     }
     
     func testRegisteringEmptyMap() {
         
         let emptyMap = Array<String>()
         
-        Iconic.registerFont(kFontName, map: emptyMap)
+        Iconic.registerFont(withPath: kFontName, map: emptyMap)
         
-        let font = Iconic.iconFontOfSize(10)
+        let font = Iconic.iconFont(ofSize: 10)
         
         XCTAssertNil(font)
     }
     
-    func testRegisteringMultipleFonts() {
+    // Fonts with zero point size would return a system font object.
+    func testFontSizeZero() {
         
-        Iconic.registerFont("MaterialIcons-Regular", map: kFakeMap)
-        Iconic.registerFont("open-iconic", map: kFakeMap)
-        Iconic.registerFont("FontAwesome", map: kFakeMap)
-
-        XCTAssertEqual(Iconic.icons.count, 3)
+        Iconic.registerFont(withName: kFontName, map: kFakeMap)
+        
+        let font = Iconic.iconFont(ofSize: 0)
+        
+        XCTAssertNil(font)
     }
 }

--- a/Samples/UnitTests/IconicFundamentalTests.swift
+++ b/Samples/UnitTests/IconicFundamentalTests.swift
@@ -26,7 +26,7 @@ class IconicFundamentalTests: XCTestCase {
     override class func setUp() {
         super.setUp()
         
-        Iconic.registerFont("FontAwesome", map: IconMap)
+        Iconic.registerFont(withName: "FontAwesome", map: IconMap)
     }
     
     override func setUp() {
@@ -47,7 +47,7 @@ class IconicFundamentalTests: XCTestCase {
     
     func testFontConstructor() {
         
-        let font = Iconic.iconFontOfSize(20)
+        let font = Iconic.iconFont(ofSize: 20)
         
         XCTAssertNotNil(font)
         XCTAssertEqual(font!.familyName, "FontAwesome")

--- a/Source/Iconic.swift
+++ b/Source/Iconic.swift
@@ -22,7 +22,7 @@ public class Iconic: NSObject {
      - parameter familyName: The font's family name available in the application's bundle to be used for registering.
      - parameter map: An array of icon glyph unicodes.
      */
-    class func registerFont(familyName: String, map: [String]) {
+    class func registerFont(withName familyName: String, map: [String]) {
         
         if let url = urlForFontWithName(familyName) {
             return registerFontFromURL(url, map:map)
@@ -37,14 +37,14 @@ public class Iconic: NSObject {
      - parameter path: The path of the font file (generally from the application bundle)
      - parameter map: An array of icon glyph unicodes.
      */
-    class func registerFontWithPath(path: String, map: [String]) {
+    class func registerFont(withPath path: String, map: [String]) {
         
         registerFontFromURL(NSURL.fileURLWithPath(path), map:map)
     }
     
     // MARK: - Font Constructor
     
-    class func iconFontOfSize(fontSize: CGFloat) -> UIFont? {
+    class func iconFont(ofSize fontSize: CGFloat) -> UIFont? {
         
         // Calling UIFont.init() with zero would return a system font object.
         if fontSize == 0 {
@@ -79,7 +79,7 @@ public class Iconic: NSObject {
     
     class func attributedString(forIndex idx: Int, size: CGFloat, color: UIColor?) -> NSAttributedString? {
 
-        guard let font = iconFontOfSize(size), let unicode = unicodeString(forIndex: idx) else {
+        guard let font = iconFont(ofSize: size), let unicode = unicodeString(forIndex: idx) else {
             return nil
         }
         


### PR DESCRIPTION
Things were being just too complex for no big benefits: the use case of registering multiple icon fonts is very limited, at least for now.

Getting rid of the ability to register more than one font and mapping list for now. This simplifies considerably.