### PR TITLE
Interface builder support. Closes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Web developers have been using icon fonts for quite some time now.
 - Fonts are registered dynamically, effortless. No need to import the file to your project.
 - [UIKit extensions](#uikit-extensions) (`UIBarButtonItem` and `UITabBarItem`).
 - Auto-generated [icon font html catalog](#icon-font-catalog).
+- Interface Builder support (prototype).
 - iOS 8, and tvOS 9 or later.
 
 _Note: Some open sourced icon fonts don't include the names of each of their glyphs. This could result in a non-descriptive enum, which can make things less intuitive for you when using Iconic. If you create your own icon font, make sure to properly name each glyph._
@@ -53,7 +54,6 @@ _Note: Some open sourced icon fonts don't include the names of each of their gly
 - [ ] Allow rectangular icon glyphs (right now, the lib assumes they're all square sized).
 - [ ] Multiple-font support.
 - [ ] More Swifty approach.
-- [ ] Interface Builder support.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ _Note: Some open sourced icon fonts don't include the names of each of their gly
 
 
 ### Missing Features in Beta
-- [ ] Allow rectangular icon glyphs (right now, the lib assumes they're all square sized).
-- [ ] Multiple-font support.
-- [ ] More Swifty approach.
+- [ ] Interface Builder Support.
+- [ ] Solid API definition with a more Swifty approach (see #2 and #26).
+- [ ] Fully covered with snapshot tests.
 
 
 ## Installation

--- a/Samples/Samples.xcodeproj/project.pbxproj
+++ b/Samples/Samples.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		6E2DE7CEADCF7D32164DC25C /* Pods_tvOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 613918C3DF2AB61F725228B6 /* Pods_tvOS.framework */; };
 		DEB0B7DA7E3B9A18FB7946DC /* Pods_iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5723503241FCD7C2A31D8D92 /* Pods_iOS.framework */; };
 		EB381FDCA4BBF8AD9C34DE2E /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6598691EE34A35192F2A2E34 /* Pods_UnitTests.framework */; };
+		F502824E1D6E011B00E1AA12 /* IconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F502824D1D6E011B00E1AA12 /* IconView.swift */; };
 		F50ADC061D112CDA004A5A4C /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F50ADC041D112CDA004A5A4C /* Main.storyboard */; };
 		F50ADC081D112CDA004A5A4C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F50ADC071D112CDA004A5A4C /* Assets.xcassets */; };
 		F50ADC111D112D0B004A5A4C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50ADC0F1D112D0B004A5A4C /* AppDelegate.swift */; };
@@ -51,6 +52,7 @@
 		78230169932E450203A516F0 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BB4D491A35D9B967184245DF /* Pods-iOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-iOS/Pods-iOS.debug.xcconfig"; sourceTree = "<group>"; };
 		F00FE753C2446C1FC931C7C0 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
+		F502824D1D6E011B00E1AA12 /* IconView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconView.swift; sourceTree = "<group>"; };
 		F50ADBFE1D112CDA004A5A4C /* tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F50ADC051D112CDA004A5A4C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		F50ADC071D112CDA004A5A4C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -189,6 +191,7 @@
 				F54BAFC31D0A609F004757C9 /* SecondViewController.swift */,
 				F54BAFC41D0A609F004757C9 /* ThirdViewController.h */,
 				F54BAFC51D0A609F004757C9 /* ThirdViewController.m */,
+				F502824D1D6E011B00E1AA12 /* IconView.swift */,
 				F54BAFC11D0A609F004757C9 /* iOS-Bridging-Header.h */,
 			);
 			path = Classes;
@@ -627,6 +630,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F502824E1D6E011B00E1AA12 /* IconView.swift in Sources */,
 				F54BAFCC1D0A609F004757C9 /* ThirdViewController.m in Sources */,
 				F54BAFCA1D0A609F004757C9 /* FirstViewController.swift in Sources */,
 				F54BAFCB1D0A609F004757C9 /* SecondViewController.swift in Sources */,

--- a/Samples/Samples.xcworkspace/contents.xcworkspacedata
+++ b/Samples/Samples.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Playground.playground">
+   </FileRef>
+   <FileRef
       location = "group:Samples.xcodeproj">
    </FileRef>
    <FileRef

--- a/Samples/iOS/Base.lproj/Main.storyboard
+++ b/Samples/iOS/Base.lproj/Main.storyboard
@@ -9,7 +9,7 @@
         <!--First View Controller-->
         <scene sceneID="UVg-rd-jcR">
             <objects>
-                <tableViewController id="4qd-Ww-v5p" customClass="FirstViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="4qd-Ww-v5p" customClass="FirstViewController" customModule="iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="Ore-9V-wE0">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -55,7 +55,7 @@
         <!--Second View Controller-->
         <scene sceneID="Pls-5z-YHW">
             <objects>
-                <viewController id="0yR-jT-3Z1" customClass="SecondViewController" customModule="Example" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="0yR-jT-3Z1" customClass="SecondViewController" customModule="iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="bR3-Sc-2Ar"/>
                         <viewControllerLayoutGuide type="bottom" id="se9-zp-Tve"/>
@@ -65,44 +65,53 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Adjust the slider to update the size of the icon image." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xJw-Ut-2nB">
-                                <rect key="frame" x="75" y="547" width="450" height="4"/>
+                                <rect key="frame" x="75" y="496" width="450" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="VOy-KG-hQJ"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                 <color key="textColor" red="0.70488542259999998" green="0.70488542259999998" blue="0.70488542259999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="1" maxValue="30" translatesAutoresizingMaskIntoConstraints="NO" id="ZNm-eS-cnB" customClass="StepSlider" customModule="Example" customModuleProvider="target">
-                                <rect key="frame" x="130" y="505" width="341" height="31"/>
+                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="200" minValue="20" maxValue="420" translatesAutoresizingMaskIntoConstraints="NO" id="ZNm-eS-cnB" customClass="StepSlider" customModule="iOS" customModuleProvider="target">
+                                <rect key="frame" x="130" y="454" width="341" height="31"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="337" id="s5i-s7-dEp"/>
+                                    <constraint firstAttribute="width" constant="337" id="JfI-Tb-dtu"/>
                                 </constraints>
                                 <connections>
                                     <action selector="didChangeScale:" destination="0yR-jT-3Z1" eventType="valueChanged" id="twA-vQ-kjo"/>
                                 </connections>
                             </slider>
-                            <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="VnG-T5-pMn">
-                                <rect key="frame" x="20" y="72" width="560" height="425"/>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zL9-Fl-E3t" customClass="IconView" customModule="iOS" customModuleProvider="target">
+                                <rect key="frame" x="200" y="200" width="200" height="200"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.052886746453900707" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="425" id="Qkl-pB-gJR"/>
+                                    <constraint firstAttribute="width" constant="200" id="D5X-ag-TMz"/>
+                                    <constraint firstAttribute="height" constant="200" id="fn3-2h-sdi"/>
                                 </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="github"/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="iconColor">
+                                        <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="xJw-Ut-2nB" firstAttribute="bottom" secondItem="se9-zp-Tve" secondAttribute="top" id="1eg-Wo-Bhh"/>
-                            <constraint firstItem="xJw-Ut-2nB" firstAttribute="leading" secondItem="iGm-Kc-Plu" secondAttribute="leadingMargin" constant="55" id="1fm-KR-zbk"/>
-                            <constraint firstItem="VnG-T5-pMn" firstAttribute="centerX" secondItem="ZNm-eS-cnB" secondAttribute="centerX" id="ABy-O5-Zqs"/>
-                            <constraint firstItem="xJw-Ut-2nB" firstAttribute="centerX" secondItem="ZNm-eS-cnB" secondAttribute="centerX" id="GGi-bp-G81"/>
-                            <constraint firstItem="se9-zp-Tve" firstAttribute="top" secondItem="ZNm-eS-cnB" secondAttribute="bottom" constant="16" id="RcM-ey-O4e"/>
-                            <constraint firstItem="xJw-Ut-2nB" firstAttribute="top" secondItem="VnG-T5-pMn" secondAttribute="bottom" constant="50" id="S7E-Cj-vcM"/>
-                            <constraint firstItem="ZNm-eS-cnB" firstAttribute="top" secondItem="VnG-T5-pMn" secondAttribute="bottom" constant="8" symbolic="YES" id="Z6J-PR-OcG"/>
-                            <constraint firstItem="VnG-T5-pMn" firstAttribute="top" secondItem="bR3-Sc-2Ar" secondAttribute="bottom" constant="8" symbolic="YES" id="aYi-yR-rGH"/>
-                            <constraint firstItem="VnG-T5-pMn" firstAttribute="leading" secondItem="iGm-Kc-Plu" secondAttribute="leadingMargin" id="e6O-r4-xjk"/>
-                            <constraint firstItem="VnG-T5-pMn" firstAttribute="trailing" secondItem="iGm-Kc-Plu" secondAttribute="trailingMargin" id="uli-Rx-krQ"/>
+                            <constraint firstItem="zL9-Fl-E3t" firstAttribute="centerX" secondItem="ZNm-eS-cnB" secondAttribute="centerX" id="2EK-a0-QvP"/>
+                            <constraint firstItem="xJw-Ut-2nB" firstAttribute="top" secondItem="ZNm-eS-cnB" secondAttribute="bottom" constant="12" id="J2Q-LO-f6F"/>
+                            <constraint firstItem="ZNm-eS-cnB" firstAttribute="centerX" secondItem="xJw-Ut-2nB" secondAttribute="centerX" id="JDS-jI-Yst"/>
+                            <constraint firstItem="se9-zp-Tve" firstAttribute="top" secondItem="xJw-Ut-2nB" secondAttribute="bottom" constant="15" id="Xrr-HF-aXo"/>
+                            <constraint firstItem="xJw-Ut-2nB" firstAttribute="leading" secondItem="iGm-Kc-Plu" secondAttribute="leadingMargin" constant="55" id="bpo-fH-MET"/>
+                            <constraint firstItem="zL9-Fl-E3t" firstAttribute="centerX" secondItem="iGm-Kc-Plu" secondAttribute="centerX" id="mvY-6E-wxM"/>
+                            <constraint firstItem="zL9-Fl-E3t" firstAttribute="centerY" secondItem="iGm-Kc-Plu" secondAttribute="centerY" id="t87-M2-fWq"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="R6Q-pv-5bf"/>
                     <connections>
-                        <outlet property="imageView" destination="VnG-T5-pMn" id="fcY-eN-M2F"/>
+                        <outlet property="iconHeightConstraint" destination="fn3-2h-sdi" id="PQm-Im-uda"/>
+                        <outlet property="iconWidthConstraint" destination="D5X-ag-TMz" id="GHZ-OM-cAM"/>
                         <outlet property="slider" destination="ZNm-eS-cnB" id="KVj-i6-sEG"/>
                     </connections>
                 </viewController>

--- a/Samples/iOS/Base.lproj/Main.storyboard
+++ b/Samples/iOS/Base.lproj/Main.storyboard
@@ -84,7 +84,6 @@
                             </slider>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="zL9-Fl-E3t" customClass="IconView" customModule="iOS" customModuleProvider="target">
                                 <rect key="frame" x="200" y="200" width="200" height="200"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.052886746453900707" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="200" id="D5X-ag-TMz"/>
                                     <constraint firstAttribute="height" constant="200" id="fn3-2h-sdi"/>

--- a/Samples/iOS/Classes/IconView.swift
+++ b/Samples/iOS/Classes/IconView.swift
@@ -1,0 +1,114 @@
+//
+//  IconView.swift
+//  Samples
+//
+//  Created by Ignacio Romero on 7/28/16.
+//  Copyright © 2016 DZN. All rights reserved.
+//
+
+import UIKit
+import Iconic
+
+@IBDesignable
+class IconView: UIImageView {
+    
+    // MARK: - Public & Inspectable variables
+    
+    @available(*, unavailable, message = "This property is reserved for Interface Builder. Use 'icon' instead.")
+    @IBInspectable var iconName: String? {
+        willSet {
+            icon = Icon(named: newValue ?? "")
+        }
+    }
+    
+    @available(*, unavailable, message = "This property is reserved for Interface Builder. Use 'tintColor' instead.")
+    @IBInspectable var iconColor: UIColor! {
+        willSet {
+            tintColor = newValue ?? .blackColor()
+        }
+    }
+    
+    var icon: Icon? {
+        didSet {
+            updateIconImage()
+        }
+    }
+    
+    private func commonInit() {
+        self.backgroundColor = .clearColor()
+    }
+    
+    // MARK: - Overrides
+    
+    init(icon: Icon!) {
+        super.init(image: nil)
+        commonInit()
+        self.icon = icon
+    }
+    
+    required override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+    
+    override var image: UIImage? {
+        get { return nil }
+        set {}
+    }
+    
+    override var tintColor: UIColor! {
+        didSet {
+            updateIconImage()
+        }
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        updateIconImage()
+    }
+    
+    @available(*, unavailable, message = "Reserved for when designable objects are created in Interface Builder.")
+    override func prepareForInterfaceBuilder() {
+        Iconic.registerIconFont()
+    }
+    
+    // MARK: - Constructor
+    
+    func updateIconImage() {
+        
+        // no need to update if the sizing is empty or too small
+        if CGRectIsEmpty(frame) ||
+            CGRectIsNull(frame) ||
+            CGRectGetWidth(frame) < 5 {
+            return
+        }
+
+        if icon == nil {
+            super.image = nil
+        }
+        else {
+            let size = max(CGRectGetWidth(frame), CGRectGetHeight(frame))
+            let image = Iconic.image(forIcon: icon!, size: size, color: tintColor)
+            
+            super.image = image
+        }
+    }
+}
+
+extension Icon {
+    
+    init(named iconName: String) {
+        switch iconName.lowercaseString {
+        case "dribble": self = .Dribble
+        case "dropbox": self = .Dropbox
+        case "github":  self = .Github
+        default: self = TotalCount
+        }
+    }
+}

--- a/Samples/iOS/Classes/SecondViewController.swift
+++ b/Samples/iOS/Classes/SecondViewController.swift
@@ -11,13 +11,10 @@ import Iconic
 
 class SecondViewController: UIViewController {
     
-    @IBOutlet weak var imageView: UIImageView!
+    @IBOutlet weak var iconView: IconView!
+    @IBOutlet weak var iconWidthConstraint: NSLayoutConstraint!
+    @IBOutlet weak var iconHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var slider: UISlider!
-    
-    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-        commonInit()
-    }
     
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -37,8 +34,8 @@ class SecondViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        updateImage(1.0)
         updateTitleView()
+        updateIcon(200)
     }
     
     override func viewWillAppear(animated: Bool) {
@@ -53,15 +50,17 @@ class SecondViewController: UIViewController {
     @IBAction func didChangeScale(sender: UISlider) {
         print("did change scale to '\(sender.value)'")
         
-        updateImage(sender.value)
+        updateIcon(sender.value)
     }
     
-    func updateImage(scale: Float) {
+    func updateIcon(scale: Float) {
         
-        let size = ceil(20.0 * scale)
-        let image = Iconic.image(forIcon: .GithubAlt, size: CGFloat(size), color: .blackColor())
+        let size = CGFloat(ceil(scale))
         
-        imageView.image = image
+        // Need to figure out a better way to update both axis with 1 single constraint.
+        // Maybe with aspect ratio 1:1 ?
+        iconWidthConstraint.constant = size
+        iconHeightConstraint.constant = size
     }
 }
 

--- a/Source/iconic-default.stencil
+++ b/Source/iconic-default.stencil
@@ -120,6 +120,19 @@ A list with available glyphs detected from the icon font.
 }
 
 /**
+Convenience Initializer of an Icon enum out of its name.
+*/
+extension Icon {
+    init(named iconName: String) {
+        switch iconName.lowercaseString {
+        {% for icon in icons %}
+        case "{{icon.name|swiftIdentifier|snakeToCamelCase}}": self = .{{icon.name|swiftIdentifier|snakeToCamelCase}}
+        {% endfor %}
+        }
+    }
+}
+
+/**
 A list of unicode characters associated with each Icon case, in order.
 */
 public let IconMap: Array<String> = [

--- a/Source/iconic-default.stencil
+++ b/Source/iconic-default.stencil
@@ -120,19 +120,6 @@ A list with available glyphs detected from the icon font.
 }
 
 /**
-Convenience Initializer of an Icon enum out of its name.
-*/
-extension Icon {
-    init(named iconName: String) {
-        switch iconName.lowercaseString {
-        {% for icon in icons %}
-        case "{{icon.name|swiftIdentifier|snakeToCamelCase}}": self = .{{icon.name|swiftIdentifier|snakeToCamelCase}}
-        {% endfor %}
-        }
-    }
-}
-
-/**
 A list of unicode characters associated with each Icon case, in order.
 */
 public let IconMap: Array<String> = [


### PR DESCRIPTION
Initial support for Interface Builder:
![image](https://cloud.githubusercontent.com/assets/590579/17939406/e530138e-6a00-11e6-97e7-ca952e3fdec8.png)

Created a new `UIImageView` subclass, called `IconView.swift`. This class uses 2 IBInspectable attributes, `iconName` and `iconColor`. The `iconName` attribute expects a string, internally converted to an enum, to be able to use Iconic's image converter. The image is then assigned to its super's `image` property.

This is still a prototype, specially because I need to figure out a nice way to convert String to enum, without having to create yet another long function using SwiftGen. It seems like Swift 3 brings a few new features to do this with a simple function.
I will integrate this class into Iconic once I port most of the APIs to a more Swifty and Swift 3 compatible interface, just like in #26.