### PR TITLE
Update .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,9 +6,9 @@ coverage:
   round: nearest
   range: 70...100
   ignore:
-    - Vendor/*
-    - Samples/*
-    - */Pods/*
+    - Vendor/.*
+    - Samples/.*
+    - .*/Pods/.*
 
   status:
     project: true


### PR DESCRIPTION
Our new pattern matching broke this style in effort to respect both Glob and Regexp. We are considering adding it back, but for now this will patch it up.