### PR TITLE
INPUT_PATH & CUSTOM_NAME passed via environment variable

### DIFF
--- a/Iconic.podspec
+++ b/Iconic.podspec
@@ -26,5 +26,5 @@ Pod::Spec.new do |s|
 
   s.swift_version             = '5.0'
 
-  s.prepare_command           = "sh Source/Iconizer.sh '#{ENV['FONT_PATH']}' '#{ENV['CUSTOM_FONT_NAME']}'"
+  s.prepare_command           = "sh Source/Iconizer.sh"
 end

--- a/Source/Iconizer.sh
+++ b/Source/Iconizer.sh
@@ -6,11 +6,11 @@
 #  Script in charge of executing SwiftGen, passing the icon font file path, the enum name and the custom stencil as arguments.
 #
 
-# The optional font file path passed as arg
-INPUT_PATH=$1
+# The optional font file path passed as environemnt variable
+INPUT_PATH=$FONT_PATH
 
 # The optional custom name to use instead of deriving one via file name
-CUSTOM_NAME=$2
+CUSTOM_NAME=$CUSTOM_FONT_NAME
 
 # The root path for the generated files
 OUTPUT_PATH=Source


### PR DESCRIPTION
**Description:** This avoids changing checksum values Podfile.lock on different computer.
**Why we need this?**
When our teammates run `pod install` on different computer & CI/CD, get different sha checksum for Iconic pod. It turns out cocoapods uses local podspec.json files to generate this hash values. (For more [details](https://artsy.github.io/blog/2016/05/03/podspec-checksums/))

Current Iconic.podspec files passes `FONT_PATH` & `CUSTOM_FONT_NAME` variables via args in `prepare_command`. Since `FONT_PATH` value is not relative path, it varies on on each computer. So I removed `FONT_PATH` & `CUSTOM_FONT_NAME` values in podspec then access their values via Environment Variables.